### PR TITLE
增加内存申请和释放接口，包括内存池

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,14 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 
 PROJECT(tongsuo-mini)
 
+if (MSVC)
+    # warning level 4 and all warnings as errors
+    add_compile_options(/W4 /WX)
+else()
+    # lots of warnings and all warnings as errors
+    add_compile_options(-Wall -Wextra -pedantic -Werror)
+endif()
+
 set(VERSION_MAJOR 0)
 set(VERSION_MINOR 9)
 set(VERSION_PATCH 0)
@@ -11,12 +19,8 @@ add_definitions(-DTONGSUO_MINI_VERSION="${VERSION_MAJOR}.${VERSION_MINOR}.${VERS
 
 include_directories(include)
 
-set(LIB_SRC
-    src/version.c
-    src/log.c
-)
-
-add_library(tongsuo-mini ${LIB_SRC})
+file(GLOB_RECURSE lib_sources CONFIGURE_DEPENDS "src/*.c")
+add_library(tongsuo-mini ${lib_sources})
 
 add_executable(minisuo app/minisuo.c)
 target_link_libraries(minisuo LINK_PUBLIC tongsuo-mini)

--- a/include/internal/mem.h
+++ b/include/internal/mem.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 The Tongsuo Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/Tongsuo-Project/tongsuo-mini/blob/main/LICENSE
+ */
+
+#if !defined(TONGSUOMINI_MEM_H)
+# define TONGSUOMINI_MEM_H
+# pragma once
+
+# include <stddef.h>
+
+void *tsm_alloc(size_t size);
+void *tsm_calloc(size_t size);
+void tsm_free(void *ptr);
+void tsm_memzero(void *ptr, size_t size);
+
+#endif

--- a/include/internal/pool.h
+++ b/include/internal/pool.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 The Tongsuo Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/Tongsuo-Project/tongsuo-mini/blob/main/LICENSE
+ */
+
+#if !defined(TONGSUOMINI_POOL_H)
+# define TONGSUOMINI_POOL_H
+# pragma once
+
+# include <stddef.h>
+
+typedef struct tsm_pool_s tsm_pool_t;
+
+tsm_pool_t *ngx_create_pool(size_t size);
+void tsm_destroy_pool(tsm_pool_t *pool);
+void *tsm_palloc(tsm_pool_t *pool, size_t size);
+void *tsm_pcalloc(tsm_pool_t *pool, size_t size);
+
+#endif

--- a/src/mem.c
+++ b/src/mem.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 The Tongsuo Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/Tongsuo-Project/tongsuo-mini/blob/main/LICENSE
+ */
+
+#include <internal/log.h>
+#include <internal/mem.h>
+#include <stdlib.h>
+#include <string.h>
+
+void *tsm_alloc(size_t size)
+{
+    void *ptr = malloc(size);
+    tsm_debug("malloc %p:%z", ptr, size);
+    return ptr;
+}
+
+void *tsm_calloc(size_t size)
+{
+    void *ptr;
+
+    ptr = tsm_alloc(size);
+    if (ptr)
+        tsm_memzero(ptr, size);
+
+    return ptr;
+}
+
+void tsm_free(void *ptr)
+{
+    free(ptr);
+    tsm_debug("free %p", ptr);
+}
+
+inline void tsm_memzero(void *ptr, size_t size)
+{
+    (void)memset(ptr, 0, size);
+}

--- a/src/pool.c
+++ b/src/pool.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2023 The Tongsuo Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/Tongsuo-Project/tongsuo-mini/blob/main/LICENSE
+ */
+
+#include <internal/log.h>
+#include <internal/mem.h>
+#include <internal/pool.h>
+#include <stdlib.h>
+
+typedef struct {
+    unsigned char *last;
+    unsigned char *end;
+    tsm_pool_t *next;
+    int failed;
+} tsm_pool_data_t;
+
+struct tsm_pool_s {
+    tsm_pool_data_t d;
+    tsm_pool_t *current;
+};
+
+static void *tsm_palloc_block(tsm_pool_t *pool, size_t size);
+
+tsm_pool_t *ngx_create_pool(size_t size)
+{
+    tsm_pool_t *p;
+
+    p = tsm_alloc(size);
+    if (p == NULL) {
+        return NULL;
+    }
+
+    p->d.last = (unsigned char *)p + sizeof(tsm_pool_t);
+    p->d.end = (unsigned char *)p + size;
+    p->d.next = NULL;
+    p->d.failed = 0;
+
+    size = size - sizeof(tsm_pool_t);
+    p->current = p;
+
+    tsm_debug("create pool %p:%z", p, size);
+    return p;
+}
+
+void tsm_destroy_pool(tsm_pool_t *pool)
+{
+    tsm_pool_t *p, *n;
+    tsm_debug("destroy pool %p", pool);
+
+    for (p = pool, n = pool->d.next;; p = n, n = n->d.next) {
+        tsm_free(p);
+
+        if (n == NULL) {
+            break;
+        }
+    }
+}
+
+void *tsm_palloc(tsm_pool_t *pool, size_t size)
+{
+    unsigned char *m;
+    tsm_pool_t *p;
+
+    tsm_debug("palloc %p:%z", pool, size);
+
+    p = pool->current;
+
+    do {
+        m = p->d.last;
+
+        if ((size_t)(p->d.end - m) >= size) {
+            p->d.last = m + size;
+
+            return m;
+        }
+
+        p = p->d.next;
+
+    } while (p);
+
+    return tsm_palloc_block(pool, size);
+}
+
+static void *tsm_palloc_block(tsm_pool_t *pool, size_t size)
+{
+    unsigned char *m;
+    size_t psize;
+    tsm_pool_t *p, *new;
+
+    psize = (size_t)(pool->d.end - (unsigned char *)pool);
+
+    m = tsm_alloc(psize);
+    if (m == NULL) {
+        return NULL;
+    }
+
+    new = (tsm_pool_t *)m;
+
+    new->d.end = m + psize;
+    new->d.next = NULL;
+    new->d.failed = 0;
+
+    m += sizeof(tsm_pool_data_t);
+    new->d.last = m + size;
+
+    for (p = pool->current; p->d.next; p = p->d.next) {
+        if (p->d.failed++ > 4) {
+            pool->current = p->d.next;
+        }
+    }
+
+    p->d.next = new;
+
+    return m;
+}
+
+void *tsm_pcalloc(tsm_pool_t *pool, size_t size)
+{
+    void *p;
+
+    p = tsm_palloc(pool, size);
+    if (p) {
+        tsm_memzero(p, size);
+    }
+
+    tsm_debug("pcalloc %p:%p:%z", pool, p, size);
+    return p;
+}


### PR DESCRIPTION
对于每个会话使用一个pool来统一分配内存。
对于非会话的内存管理可以直接使用tsm_alloc()等接口，或者考虑使用全局的pool来管理，
使用全局的pool需要考虑多线程同步问题。