### PR TITLE
Fix some compilation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ~~~
 brew install cmake
 brew install python
-sudo pip3 install pytest
+sudo pip3 install -r test/requirements.txt
 ~~~
 
 ## 构建

--- a/include/internal/log.h
+++ b/include/internal/log.h
@@ -28,7 +28,7 @@ void tsm_log(const char *file, int line, int level, const char *fmt, ...);
 #  define LOGD(...)
 #  define LOGE(...)
 #  define LOGERR(...)
-#  define ERRLOG(...)
+#  define ERRLOG(e) e
 # endif
 
 #endif

--- a/src/ascon.c
+++ b/src/ascon.c
@@ -64,11 +64,15 @@
 /* set padding byte in 64-bit Ascon word */
 #define PAD(i) SETBYTE(0x80, i)
 
+#ifdef TSM_LOG
 static void printstate(const char *label, ascon_state_t *s)
 {
     LOGD("%s:\tx0=%016llu x1=%016llu x2=%016llu x3=%016llu x4=%016llu", label, s->x[0], s->x[1],
          s->x[2], s->x[3], s->x[4]);
 }
+#else
+#define printstate(...)
+#endif
 
 /* load bytes into 64-bit Ascon word */
 static inline uint64_t LOADBYTES(const uint8_t *bytes, int n)


### PR DESCRIPTION
When TSM_LOG is not defined, it will not compile, this commit addresses this problem.

Besides, the newly added dependency pytest-subtests is not documented as well. This commit documents that part in README.md.